### PR TITLE
Improve search result matching

### DIFF
--- a/bin/open-datadog-dashboard
+++ b/bin/open-datadog-dashboard
@@ -37,16 +37,58 @@ function fetch_cached_datadog_dashboards {
 }
 
 function filter_results {
-  jq ".[] | sort_by(.title) | map(select(.title | contains(\"${search_term}\")))"
+  grep -i "$search_term"
 }
 
-function present_alfred_items {
-   jq --raw-output "map(\"<item arg=\\\"\(.id)\\\" autocomplete=\\\"\(.title)\\\">\n  <title>\(.title)</title>\n  <icon>datadog-logo.png</icon>\n</item>\n\")[]"
+function columnize_data {
+  # maps over each item in the array and returns data in 4 columns
+  #
+  # 1. id - the ID of the dashboard
+  # 2. tokenized title (first letters split by spaces) - first letter of each word in the dashboard's title
+  #                this provides an alternative way to match titles
+  #                example: "My Awesome App" becomes "MAA"
+  # 3. tokenized title (first letters split by hyphens) - first letter of each hypenated word in the dashboard's title
+  #                this provides an alternative way to match titles
+  #                example: "my-awesome-app" becomes "maa"
+  # 4. title - the full dashboard title
+
+  jq --raw-output 'map("\(.id) \(.title | split(" ") | map(explode[0]) | implode) \(.title | split("-") | map(explode[0]) | implode) \(.title)")[]' | column -c 4
 }
 
-echo '<?xml version="1.0"?>'
-echo '<items>'
+function alfred_items {
+  if [ "$search_term" == "" ]; then
+    fetch_cached_datadog_dashboards | sort_data | columnize_data
+  else
+    fetch_cached_datadog_dashboards | sort_data | columnize_data | filter_results
+  fi
+}
 
-  fetch_cached_datadog_dashboards | filter_results | present_alfred_items
+function present_alfred_item {
+  local id="$1"
+  shift 3
+  local title="$*"
+  if [ "$1" != "" ]; then
+    cat << EOS
+  <item arg="$id" autocomplete="$title">
+    <title>$title</title>
+    <subtitle>Open the "$title" dashboard in Datadog...</subtitle>
+    <subtitle mod="shift">Copy "https://app.datadoghq.com/dash/$title" to your clipboard...</subtitle>
+    <text type="copy">https://app.datadoghq.com/dash/$id</text>
+    <icon>datadog-logo.png</icon>
+  </item>
+EOS
+  fi
+}
 
-echo '</items>'
+function main {
+  echo '<?xml version="1.0"?>'
+  echo '<items>'
+
+  while read -r item; do
+    present_alfred_item $item
+  done <<< "$(alfred_items)"
+
+  echo '</items>'
+}
+
+main

--- a/bin/open-datadog-dashboard
+++ b/bin/open-datadog-dashboard
@@ -8,8 +8,17 @@ search_term="${1}"
 # TODO make configurable and/or move to Alfred's workspace?
 cache_path="/tmp/datadog-dashboards.json"
 
+function sort_data {
+  jq 'sort_by(.title)'
+}
+
+function select_data {
+  jq 'map({id, title})'
+}
+
 function fetch_dashboards_from_datadog_api {
-  curl -s "https://app.datadoghq.com/api/v1/dash?api_key=${DATADOG_API_KEY}&application_key=${DATADOG_APP_KEY}" > $cache_path
+  local api_url="https://app.datadoghq.com/api/v1/dash?api_key=${DATADOG_API_KEY}&application_key=${DATADOG_APP_KEY}"
+  curl -s "$api_url" | jq '.[]' | select_data | sort_data > $cache_path
   cat $cache_path
 }
 


### PR DESCRIPTION
This adds the following improvements to matching:
1. ignores case
2. matches first letter of words split by spaces (ex. "ma" matches "my app app")
3. matches first letter of words split by hyphens (ex. "pds" matches
   "production-database-server")

As part of this, I also moved xml "rendering" out of `jq` and into a `for`
loop. This should be easier to read and maintain.

Note: improvements 2 and 3 are not quite where I would like them. For example,
"my awesome-app" gets tokenized as "ma" and "aa". I would prefer that to be
"maa".  Also, other characters are not filtered, so "my (awesome) app" gets
tokenized as "m(a". I may look at addressing those issues in the future, but I
also may have reached the limit of what I can reasonably do with curl + jq :).
