### PR TITLE
Copy url to clipboard

### DIFF
--- a/config/info.plist
+++ b/config/info.plist
@@ -16,6 +16,14 @@
 				<key>modifiersubtext</key>
 				<string></string>
 			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>A07AFF79-DB16-4B8F-9200-2803F116A3BE</string>
+				<key>modifiers</key>
+				<integer>131072</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+			</dict>
 		</array>
 	</dict>
 	<key>createdby</key>
@@ -83,6 +91,21 @@ PATH="${PATH}:${PWD}"
 			<key>version</key>
 			<integer>0</integer>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>autopaste</key>
+				<true/>
+				<key>clipboardtext</key>
+				<string>https://app.datadoghq.com/dash/{query}</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.clipboard</string>
+			<key>uid</key>
+			<string>A07AFF79-DB16-4B8F-9200-2803F116A3BE</string>
+			<key>version</key>
+			<integer>0</integer>
+		</dict>
 	</array>
 	<key>readme</key>
 	<string></string>
@@ -96,7 +119,12 @@ PATH="${PATH}:${PWD}"
 		<key>6C68D0BB-A89A-4FDD-BB99-B5A5B460646E</key>
 		<dict>
 			<key>ypos</key>
-			<real>60</real>
+			<real>210</real>
+		</dict>
+		<key>A07AFF79-DB16-4B8F-9200-2803F116A3BE</key>
+		<dict>
+			<key>ypos</key>
+			<real>270</real>
 		</dict>
 	</dict>
 	<key>webaddress</key>


### PR DESCRIPTION
This provides the option to copy the url to clipboard instead of opening the
url.

To use this option, hit <shift> and <enter> when the dashboard is highlighted
in the results.
